### PR TITLE
Join outstanding Robodash threads on application exit

### DIFF
--- a/lib/robodash.rb
+++ b/lib/robodash.rb
@@ -60,10 +60,6 @@ module Robodash
         @threads = value
       end
 
-      def mutex
-        @mutex ||= Mutex.new
-      end
-
       def parse_schedule(schedule)
         schedule = schedule.to_s.strip.downcase
         return predefined_schedules[schedule] if predefined_schedules[schedule]
@@ -89,18 +85,16 @@ module Robodash
         return false unless enabled?
         return false unless api_token
 
-        mutex.synchronize do
-          threads << Thread.new do
-            Thread.current.abort_on_exception = false
+        threads << Thread.new do
+          Thread.current.abort_on_exception = false
 
-            begin
-              send_api_request(endpoint, body)
-            rescue => e
-              warn_safely("Robodash request failed: #{e.class} - #{e.message}")
-            end
+          begin
+            send_api_request(endpoint, body)
+          rescue => e
+            warn_safely("Robodash request failed: #{e.class} - #{e.message}")
           end
-          threads = self.threads.select(&:alive?)
         end
+        threads = self.threads.select(&:alive?)
 
         true
       end

--- a/lib/robodash.rb
+++ b/lib/robodash.rb
@@ -56,8 +56,9 @@ module Robodash
         @threads ||= []
       end
 
-      def threads=(value)
-        @threads = value
+      def track_thread(&block)
+        threads << Thread.new(&block)
+        threads.select!(&:alive?)
       end
 
       def parse_schedule(schedule)
@@ -85,7 +86,7 @@ module Robodash
         return false unless enabled?
         return false unless api_token
 
-        threads << Thread.new do
+        track_thread do
           Thread.current.abort_on_exception = false
 
           begin
@@ -94,7 +95,6 @@ module Robodash
             warn_safely("Robodash request failed: #{e.class} - #{e.message}")
           end
         end
-        threads = self.threads.select(&:alive?)
 
         true
       end


### PR DESCRIPTION
When using Robodash in short lived environments like a rake task, the
child thread can be killed by the main thread before it finishes
execution.  This means we could miss pings if they occur at the end of
a rake task.

To avoid this we keep track of the spawned threads and make sure to
join any that are still alive on main application exit.